### PR TITLE
Support Blender 4.X

### DIFF
--- a/source/GUI_ops.py
+++ b/source/GUI_ops.py
@@ -153,7 +153,7 @@ class B4BRender(bpy.types.Operator):
             if not self._execution_queue.empty() and not self._cancelled and self._step < len(self._steps):
                 f = self._execution_queue.get()
                 try:
-                    f()
+                    f() #broken in Blender 4.X - Execute_queue_loop
                 except Exception as e:
                     self._exception = e
                     self._cancelled = True

--- a/source/LOD.py
+++ b/source/LOD.py
@@ -98,7 +98,7 @@ class LOD:
         r"""Export a list of sliced LOD objects as a single .obj file"""
         with bpy.context.temp_override(selected_objects=lod_objects):
             # In Blender 4+, bpy.ops.wm.obj_export can be used instead, but arguments differ
-            bpy.ops.export_scene.obj(
+            bpy.ops.export_scene.obj( #broken in Blender 4.X - export - Note This error trigger another error in ops.py in line 109 (ret = _op_call(self.idname_py(), kw))
                 filepath=filepath,
                 check_existing=False,
                 axis_up='Y',

--- a/source/Renderer.py
+++ b/source/Renderer.py
@@ -70,7 +70,7 @@ class Renderer:
         stem = tgi_formatter(gid, z.value, v.value, 0, is_model=True)
         obj_path = get_relative_path_for(f"{stem}.obj")
         mtl_path = get_relative_path_for(f"{stem}.mtl")
-        LOD.export([lod_slices[pos] for pos in tile_indices_nonempty], obj_path, v)
+        LOD.export([lod_slices[pos] for pos in tile_indices_nonempty], obj_path, v) #broken in Blender 4.X - in render_pre LOD.export
         try:
             # .obj export creates .mtl material files that are not needed
             Path(mtl_path).unlink(missing_ok=True)


### PR DESCRIPTION
Due to the lack of bug reporting this commit only serves to create a report for broken files in the Blender 4.X version that prevent the plugin from working properly.

